### PR TITLE
fix: handle stdin EOF to prevent process hang on pipe close

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -124,6 +124,10 @@ process.stdin.on('data', (chunk) => {
 });
 
 // Graceful shutdown
+process.stdin.on('end', () => {
+  process.stderr.write('stdin closed, shutting down\n');
+  process.exit(0);
+});
 process.on('SIGTERM', () => process.exit(0));
 process.on('SIGINT', () => process.exit(0));
 


### PR DESCRIPTION
Summary: Add stdin 'end' event handler that triggers clean shutdown. Fixes #23.