### PR TITLE
fix: set v4-flash thinking to true per DeepSeek API docs

### DIFF
--- a/src/models.mjs
+++ b/src/models.mjs
@@ -13,7 +13,7 @@ export const MODELS = {
     name: 'DeepSeek V4 Flash',
     contextWindow: 1_000_000,
     maxOutputTokens: 384_000,
-    thinking: false,
+    thinking: true,
     description: 'Faster and cheaper model. Best for simpler tasks, quick answers, and when latency matters more than depth.',
   },
   'deepseek-reasoner': {


### PR DESCRIPTION
Summary: deepseek-v4-flash supports thinking mode per official docs. Changed from false to true. Fixes #3.