### PR TITLE
fix: use dim() directly instead of color('dim', ...) in pricing footer

### DIFF
--- a/src/pricing.mjs
+++ b/src/pricing.mjs
@@ -39,8 +39,8 @@ export function buildFooter(result, model) {
   const lines = [
     '',
     dim('─── claude-code-deepseek-delegator · cost ───'),
-    `${color('green', 'deepseek')} ${dim(model.replace('deepseek-',''))} ${color('dim', formatCost(dsCost))}  │  ${color('yellow', 'claude sonnet 4')} ${dim(formatCost(claudeCost))}`,
-    `${color('green', 'saved')} ${bold(formatCost(saved))} ${color('green', '(' + pct + '%)')}  │  ${dim(usage.totalTokens.toLocaleString() + ' tokens')} ${color('dim', '(' + usage.promptTokens.toLocaleString() + 'p + ' + usage.completionTokens.toLocaleString() + 'c)')}`,
+    `${color('green', 'deepseek')} ${dim(model.replace('deepseek-',''))} ${dim(formatCost(dsCost))}  │  ${color('yellow', 'claude sonnet 4')} ${dim(formatCost(claudeCost))}`,
+    `${color('green', 'saved')} ${bold(formatCost(saved))} ${color('green', '(' + pct + '%)')}  │  ${dim(usage.totalTokens.toLocaleString() + ' tokens')} ${dim('(' + usage.promptTokens.toLocaleString() + 'p + ' + usage.completionTokens.toLocaleString() + 'c)')}`,
     dim('────────────────────────────────'),
   ];
 


### PR DESCRIPTION
Summary: Replace color('dim', ...) calls with dim(...) in pricing.mjs cost footer. Fixes #1.

Verification: Confirmed dim is exported as a standalone function from colors.mjs, not as a key in the color lookup.

Merge: Please use merge commit only (no squash, no rebase).