### PR TITLE
fix: include maxOutputTokens in listModels() and display it in deepseek_models (fixes #33)

### DIFF
--- a/src/models.mjs
+++ b/src/models.mjs
@@ -34,6 +34,7 @@ export function listModels() {
     id,
     name: info.name,
     contextWindow: info.contextWindow,
+    maxOutputTokens: info.maxOutputTokens,
     thinking: info.thinking,
     description: info.description,
   }));

--- a/src/tools.mjs
+++ b/src/tools.mjs
@@ -116,7 +116,7 @@ export async function handleToolCall(name, args) {
         ...models.map(
           (m) =>
             `${color('green', '●')} ${bold(m.id)} ${dim('— ' + m.name)}\n` +
-            `  ${dim('context:')} ${(m.contextWindow / 1024).toFixed(0)}K  ${dim('thinking:')} ${m.thinking ? color('green', 'on') : color('yellow', 'off')}\n` +
+            `  ${dim('context:')} ${(m.contextWindow / 1024).toFixed(0)}K  ${dim('output:')} ${(m.maxOutputTokens / 1024).toFixed(0)}K max  ${dim('thinking:')} ${m.thinking ? color('green', 'on') : color('yellow', 'off')}\n` +
             `  ${dim(m.description)}\n`
         ),
         dim('─────────────────────────────────────'),


### PR DESCRIPTION
## Summary
`listModels()` now includes `maxOutputTokens` in the returned object. The `deepseek_models` tool display now shows the output token cap alongside context window and thinking mode.

## Changes
- `src/models.mjs`: Added `maxOutputTokens` to `listModels()` return object
- `src/tools.mjs`: Updated model display format to include output token limit

## Verification
- All 16 frame-parsing tests pass
- All init-check tests pass
- Model listing now shows: `context: 1000K  output: 384K max  thinking: on`

Fixes #33