### PR TITLE
fix: guard against negative DEEPSEEK_TIMEOUT values (fixes #30)

### DIFF
--- a/src/client.mjs
+++ b/src/client.mjs
@@ -3,7 +3,8 @@ import { MODELS } from './models.mjs';
 
 const API_HOST = process.env.DEEPSEEK_API_HOST || 'api.deepseek.com';
 const API_KEY = process.env.DEEPSEEK_API_KEY;
-const TIMEOUT_MS = parseInt(process.env.DEEPSEEK_TIMEOUT || '120000', 10);
+const rawTimeout = parseInt(process.env.DEEPSEEK_TIMEOUT || '120000', 10);
+const TIMEOUT_MS = rawTimeout > 0 ? rawTimeout : 120000;
 const MAX_RETRIES = parseInt(process.env.DEEPSEEK_MAX_RETRIES || '2', 10);
 
 class DeepSeekError extends Error {


### PR DESCRIPTION
## Summary
`parseInt('-1', 10)` returns -1 but the `||` fallback only catches `NaN`. A negative timeout bypasses the guard, causing undefined behavior with Node's `http.request({timeout: -1})`. This fix adds an explicit positive-number check.

## Changes
- `src/client.mjs`: Changed from `||` fallback to explicit `rawTimeout > 0` guard

## Verification
- All existing tests pass
- `DEEPSEEK_TIMEOUT=-1` now defaults to 120000ms instead of -1
- `DEEPSEEK_TIMEOUT=30000` still works correctly
- `DEEPSEEK_TIMEOUT=0` defaults to 120000ms (zero not valid)

Fixes #30