### PR TITLE
feat: display cache hit pricing breakdown when DeepSeek reports cached tokens (fixes #26)

### DIFF
--- a/src/client.mjs
+++ b/src/client.mjs
@@ -89,6 +89,7 @@ export async function callDeepSeek({ prompt, system, model = 'deepseek-v4-pro', 
                       promptTokens: json.usage.prompt_tokens,
                       completionTokens: json.usage.completion_tokens,
                       totalTokens: json.usage.total_tokens,
+                      cachedPromptTokens: json.usage.prompt_tokens_details?.cached_tokens || 0,
                     }
                   : null,
                 finishReason: choice?.finish_reason ?? 'unknown',

--- a/src/pricing.mjs
+++ b/src/pricing.mjs
@@ -3,9 +3,9 @@
 import { color, bold, dim } from './colors.mjs';
 
 export const PRICING = {
-  'deepseek-v4-pro': { input: 0.435, output: 0.87 },
-  'deepseek-v4-flash': { input: 0.14, output: 0.28 },
-  'deepseek-reasoner': { input: 0.55, output: 2.19 },
+  'deepseek-v4-pro': { input: 0.435, output: 0.87, cache: 0.003625 },
+  'deepseek-v4-flash': { input: 0.14, output: 0.28, cache: 0.0012 },
+  'deepseek-reasoner': { input: 0.55, output: 2.19, cache: 0.0046 },
 };
 
 // Claude comparison baseline (Sonnet 4)
@@ -39,10 +39,27 @@ export function buildFooter(result, model) {
   const lines = [
     '',
     dim('─── claude-code-deepseek-delegator · cost ───'),
-    `${color('green', 'deepseek')} ${dim(model.replace('deepseek-',''))} ${color('dim', formatCost(dsCost))}  │  ${color('yellow', 'claude sonnet 4')} ${dim(formatCost(claudeCost))}`,
-    `${color('green', 'saved')} ${bold(formatCost(saved))} ${color('green', '(' + pct + '%)')}  │  ${dim(usage.totalTokens.toLocaleString() + ' tokens')} ${color('dim', '(' + usage.promptTokens.toLocaleString() + 'p + ' + usage.completionTokens.toLocaleString() + 'c)')}`,
-    dim('────────────────────────────────'),
+    `${color('green', 'deepseek')} ${dim(model.replace('deepseek-',''))} ${dim(formatCost(dsCost))}  │  ${color('yellow', 'claude sonnet 4')} ${dim(formatCost(claudeCost))}`,
   ];
+
+  // Show cache breakdown when cache hits were reported
+  const cached = usage.cachedPromptTokens || 0;
+  if (cached > 0 && dsPricing.cache) {
+    const cacheCost = (cached / 1_000_000) * dsPricing.cache;
+    const computePromptTokens = usage.promptTokens - cached;
+    const computePricing = { ...dsPricing };
+    // Compute cost uses cache-miss (input) rate for non-cached prompt tokens
+    computePricing.cache = undefined;
+    const computeCost = calculateCost(computePromptTokens, usage.completionTokens, computePricing);
+    lines.push(
+      `  ${dim('cache')} ${dim(formatCost(cacheCost))} + ${dim('compute')} ${dim(formatCost(computeCost))}`
+    );
+  }
+
+  lines.push(
+    `${color('green', 'saved')} ${bold(formatCost(saved))} ${color('green', '(' + pct + '%)')}  │  ${dim(usage.totalTokens.toLocaleString() + ' tokens')} ${dim('(' + usage.promptTokens.toLocaleString() + 'p + ' + usage.completionTokens.toLocaleString() + 'c)')}`,
+    dim('────────────────────────────────'),
+  );
 
   return lines.join('\n');
 }


### PR DESCRIPTION
## Summary
When DeepSeek reports cached tokens via `usage.prompt_tokens_details.cached_tokens`, the cost footer now shows a cache + compute breakdown to highlight savings from context caching.

## Changes
- `src/client.mjs`: Pass `cachedPromptTokens` through the usage object from `prompt_tokens_details`
- `src/pricing.mjs`: Added cache hit pricing rates ($0.003625/M for v4-pro); modified `buildFooter` to show cache/compute split when cached tokens > 0

## Verification
- All existing tests pass
- When no cache tokens: footer unchanged
- When cached tokens present: shows `cache $0.001 + compute $0.004` breakdown line

Fixes #26