### PR TITLE
fix: ensure formatSavings pct is always a number, not string (fixes #25)

### DIFF
--- a/src/pricing.mjs
+++ b/src/pricing.mjs
@@ -23,7 +23,7 @@ export function formatCost(amount) {
 
 export function formatSavings(deepseekCost, claudeCost) {
   const saved = claudeCost - deepseekCost;
-  const pct = claudeCost > 0 ? ((saved / claudeCost) * 100).toFixed(0) : 0;
+  const pct = claudeCost > 0 ? Math.round((saved / claudeCost) * 100) : 0;
   return { saved, pct };
 }
 


### PR DESCRIPTION
## Summary
`formatSavings()` returned `pct` as a string (from `.toFixed(0)`) when cost > 0, but as a number `0` when cost = 0 — a type inconsistency. Changed to `Math.round()` for consistent numeric return type.

## Changes
- `src/pricing.mjs`: Replaced `.toFixed(0)` with `Math.round()` in `formatSavings()`

## Verification
- All existing tests pass
- `typeof formatSavings(0.005, 0.720).pct === 'number'` in all code paths
- Output unchanged — `pct` is still formatted as a string later when building the footer

Fixes #25