### PR TITLE
fix: check HTTP status before JSON.parse to avoid confusing error on non-200 responses (fixes #19)

### DIFF
--- a/src/client.mjs
+++ b/src/client.mjs
@@ -74,6 +74,13 @@ export async function callDeepSeek({ prompt, system, model = 'deepseek-v4-pro', 
           let data = '';
           res.on('data', (chunk) => (data += chunk));
           res.on('end', () => {
+            if (res.statusCode >= 400) {
+              return reject(new DeepSeekError(
+                `DeepSeek API error (${res.statusCode}): ${data.slice(0, 200)}`,
+                res.statusCode,
+                { body: data.slice(0, 1000) }
+              ));
+            }
             try {
               const json = JSON.parse(data);
               if (json.error) {


### PR DESCRIPTION
## Summary
When DeepSeek returns a non-200 response without a JSON body (e.g. 502 with HTML error page, 401 with plain text), the previous code would call `JSON.parse()` on the raw text and throw a confusing `Failed to parse response` error. This fix checks `res.statusCode` first and returns a clear error with the HTTP status and response body preview.

## Changes
- `src/client.mjs`: Added early statusCode check (>=400) before JSON.parse; shows first 200 chars of response body in error message

## Verification
- All existing tests pass
- Non-200 responses now produce: `DeepSeek API error (502): <html>...` instead of `Failed to parse response: ...`

Fixes #19