### PR TITLE
fix: use Buffer.concat instead of string concatenation for large responses (fixes #18)

### DIFF
--- a/src/client.mjs
+++ b/src/client.mjs
@@ -71,9 +71,10 @@ export async function callDeepSeek({ prompt, system, model = 'deepseek-v4-pro', 
           },
         },
         (res) => {
-          let data = '';
-          res.on('data', (chunk) => (data += chunk));
+          const chunks = [];
+          res.on('data', (chunk) => chunks.push(chunk));
           res.on('end', () => {
+            const data = Buffer.concat(chunks).toString();
             try {
               const json = JSON.parse(data);
               if (json.error) {


### PR DESCRIPTION
## Summary
Replace `data += chunk` string concatenation with `Buffer.concat(chunks)` to avoid O(n²) memory copying on large responses (~384K tokens from v4-pro max output).

## Changes
- `src/client.mjs`: Collect response chunks as Buffer array, concatenate once with `Buffer.concat()`, then convert to string

## Verification
- All 16 frame-parsing tests pass
- All init-check tests pass
- Response parsing output identical to previous implementation

Fixes #18