### PR TITLE
feat: add max buffer size limit to prevent memory exhaustion (fixes #9)

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -11,6 +11,7 @@ const PROTOCOL_VERSION = '2024-11-05';
 const SERVER_NAME = 'claude-code-deepseek-delegator';
 const SERVER_VERSION = '2.0.0';
 
+const MAX_BUFFER_SIZE = 10 * 1024 * 1024; // 10MB — MCP messages should never exceed a few KB
 let buffer = '';
 let initialized = false;
 
@@ -112,6 +113,10 @@ export function parseFrames(input, onMessage) {
 
 process.stdin.on('data', (chunk) => {
   buffer += chunk.toString();
+  if (buffer.length > MAX_BUFFER_SIZE) {
+    process.stderr.write(`WARNING: buffer exceeded ${MAX_BUFFER_SIZE} bytes — flushing to prevent memory exhaustion\n`);
+    buffer = '';
+  }
   const { remainder } = parseFrames(buffer, (msg) => {
     handle(msg.method, msg.id, msg.params || {}).catch((err) => {
       if (msg.id !== undefined) error(msg.id, -32603, err.message);


### PR DESCRIPTION
## Summary
Adds a maximum buffer size limit (10MB) to prevent memory exhaustion from malformed input, logging a warning when exceeded.

## Verification
- [x] Buffer size capped at MAX_BUFFER_SIZE
- [x] Warning logged when limit exceeded
- [x] Normal messages (few KB) unaffected

Fixes #9