### PR TITLE
refactor: remove unused createInterface import (fixes #5)

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -3,7 +3,6 @@
 // Zero dependencies — Node.js 20+ built-ins only.
 // JSON-RPC 2.0 over stdio with Content-Length framing (MCP spec compliant).
 
-import { createInterface } from 'readline';
 import { handleToolCall, TOOLS } from './tools.mjs';
 import { getDefaultModel } from './models.mjs';
 


### PR DESCRIPTION
## Summary
Removes the unused `createInterface` import from `readline` module in `src/index.mjs`.

## Verification
- [x] Import is unused throughout the codebase
- [x] No functional changes
- [x] All 16 tests pass

Fixes #5