### PR TITLE
feat: add MCP ping method for health checks (fixes #10)

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -37,6 +37,9 @@ async function handle(method, id, params) {
         serverInfo: { name: SERVER_NAME, version: SERVER_VERSION },
       });
 
+    case 'ping':
+      return respond(id, {});
+
     case 'notifications/initialized':
       return;
 


### PR DESCRIPTION
## Summary
Adds handling for the MCP `ping` method, returning an empty response with the matching id for lightweight health checks.

## Verification
- [x] Ping method returns empty result with same id
- [x] Other methods unaffected
- [x] Compatible with MCP protocol spec

Fixes #10